### PR TITLE
Botones Anterior/Siguiente en paginas de visualización singular, ajustes de botones y barra de herramientas

### DIFF
--- a/app_reports/reporte_vw.py
+++ b/app_reports/reporte_vw.py
@@ -82,15 +82,15 @@ class Read(GenericRead):
             'right': frmReporteright(instance=obj),
         }
         toolbar = GenerateReadCRUDToolbar(
-            request, self.model_name, obj.pk, self.main_data_model)
+            request, self.model_name, obj, self.main_data_model)
         if request.user.has_perm("app_reports.view_camporeporte"):
-            label = ('<i class="fas fa-columns"></i>'
-                     '<span class="d-none d-sm-inline"> Campos</span>')
+            label = '<i class="fas fa-columns"></i>'
             toolbar.append({
                 'type': 'rlink',
                 'label': label,
                 'url': reverse(
                     'camporeporte_list', kwargs={'pk_reporte': obj.pk}),
+                'title': 'Campos',
             })
         return render(request, self.html_template, {
             'titulo': obj,

--- a/html_templates/zend_django/html/form.html
+++ b/html_templates/zend_django/html/form.html
@@ -64,11 +64,11 @@ forms = {
         </div>
     </div>
     {% endif %}
-    
+
     <div class="row">
         <div class="col-sm-8 offset-md-2">
             <button type="submit" class="btn btn-outline-primary" id="btn-save" title="{% action_label 'save' %}">
-                {% action_icon 'save' %} {% action_label 'save' %}
+                {% action_icon 'save' %}
             </button>
         </div>
     </div>

--- a/html_templates/zend_django/html/toolbar.html
+++ b/html_templates/zend_django/html/toolbar.html
@@ -1,35 +1,35 @@
 <!--
 toolbar = [
-    {'type': 'rlink',       'label': 'Etiqueta',    'url': 'http://...'},
-    {'type': 'link',        'label': 'Etiqueta',    'view': 'NombreVista'},
-    {'type': 'link_pk',     'label': 'Etiqueta',    'view': 'NombreVista',  pk: 'Valor'},
-    {'type': 'link_pk_del', 'label': 'Etiqueta',    'view': 'NombreVista',  pk: 'Valor'},
-    {'type': 'button',      'label': 'Etiqueta',    'onclick': 'CodigoJS'},
+    {'type': 'rlink',       'label': 'Etiqueta',    'title': 'Titulo', 'url': 'http://...'},
+    {'type': 'link',        'label': 'Etiqueta',    'title': 'Titulo', 'view': 'NombreVista'},
+    {'type': 'link_pk',     'label': 'Etiqueta',    'title': 'Titulo', 'view': 'NombreVista',  pk: 'Valor'},
+    {'type': 'link_pk_del', 'label': 'Etiqueta',    'title': 'Titulo', 'view': 'NombreVista',  pk: 'Valor'},
+    {'type': 'button',      'label': 'Etiqueta',    'title': 'Titulo', 'onclick': 'CodigoJS'},
     {'type': 'search'},
 ]
 -->
 
-<div id="main-toolbar" class="btn-toolbar float-right" role="toolbar">
+<div id="main-toolbar" class="btn-toolbar" role="toolbar">
     <div class="btn-group" role="group">
     {% for item in toolbar %}
         {% if 'rlink' == item.type %}
-            <a href="{{ item.url }}" class="btn btn-outline-secondary">
+            <a href="{{ item.url }}" class="btn btn-outline-secondary" {% if item.title %}title="{{ item.title }}"{% endif %}>
                 {{ item.label | safe }}
             </a>
         {% elif 'link' == item.type %}
-            <a href="{% url item.view %}" class="btn btn-outline-secondary">
+            <a href="{% url item.view %}" class="btn btn-outline-secondary" {% if item.title %}title="{{ item.title }}"{% endif %}>
                 {{ item.label | safe }}
             </a>
         {% elif 'link_pk' == item.type %}
-            <a href="{% url item.view pk=item.pk %}" class="btn btn-outline-secondary">
+            <a href="{% url item.view pk=item.pk %}" class="btn btn-outline-secondary" {% if item.title %}title="{{ item.title }}"{% endif %}>
                 {{ item.label | safe }}
             </a>
         {% elif 'link_pk_del' == item.type %}
-            <a href="#" onclick="App.showDeletingConfirmation(`{% url item.view pk=item.pk %}`)" class="btn btn-outline-secondary">
+            <a href="#" onclick="App.showDeletingConfirmation(`{% url item.view pk=item.pk %}`)" class="btn btn-outline-secondary" {% if item.title %}title="{{ item.title }}"{% endif %}>
                 {{ item.label | safe }}
             </a>
         {% elif 'button' == item.type %}
-            <button type="button" class="btn btn-outline-secondary" onclick="{{ item.onclick }}">
+            <button type="button" class="btn btn-outline-secondary" onclick="{{ item.onclick }}" {% if item.title %}title="{{ item.title }}"{% endif %}>
                 {{ item.label | safe }}
             </button>
         {% elif 'search' == item.type %}

--- a/html_templates/zend_django/parametrosistema/set.html
+++ b/html_templates/zend_django/parametrosistema/set.html
@@ -101,10 +101,10 @@
 
         {% endfor %}
 
-        <button type="submit" class="btn btn-outline-primary" id="btn-save" >
-            {% action_smart_button 'save' %}
+        <button type="submit" class="btn btn-outline-primary" id="btn-save" title="{% action_label 'save' %}">
+            {% action_icon 'save' %}
         </button>
-    
+
     </form>
 
 {% endif%}

--- a/zend_django/templatetags/op_icons.py
+++ b/zend_django/templatetags/op_icons.py
@@ -17,6 +17,8 @@ Action:
  - call
  - send_whatsapp
  - reset_password
+ - next_item
+ - prev_item
 """
 
 CRUD_icons = {
@@ -36,4 +38,6 @@ Action_icons = {
     'call': '<i class="fas fa-mobile-alt"></i>',
     'send_whatsapp': '<i class="fab fa-whatsapp"></i>',
     'reset_password': '<i class="fas fa-key"></i>',
+    'prev_item': '<i class="fas fa-chevron-left"></i>',
+    'next_item': '<i class="fas fa-chevron-right"></i>',
 }

--- a/zend_django/templatetags/op_labels.py
+++ b/zend_django/templatetags/op_labels.py
@@ -17,6 +17,8 @@ Action:
  - call
  - send_whatsapp
  - reset_password
+ - next_item
+ - prev_item
 """
 
 CRUD_labels = {
@@ -36,4 +38,6 @@ Action_labels = {
     'call': 'Llamar',
     'send_whatsapp': "Enviar mensaje por What's App",
     'reset_password': 'Re-establecer contraseña',
+    'prev_item': 'Siguiente',
+    'next_item': 'Anterior',
 }

--- a/zend_django/templatetags/utils.py
+++ b/zend_django/templatetags/utils.py
@@ -3,11 +3,14 @@ Funciones de utilería para la aplicación
 """
 
 from django.contrib.contenttypes.models import ContentType
+from functools import reduce
+from django.db import models
 
-from zend_django.templatetags.op_helpers import crud_smart_button
+from zend_django.templatetags.op_helpers import (
+    crud_smart_button, crud_icon, crud_label)
 
 
-def GenerateReadCRUDToolbar(request, base_name, pk, model):
+def GenerateReadCRUDToolbar(request, base_name, object, model, label_and_icon=False):
     """
     Genera el arreglo con las opciones CRUD para para la barra de herramientas
     desplegada, normalmente, en las vistas READ de la administración de los
@@ -42,19 +45,92 @@ def GenerateReadCRUDToolbar(request, base_name, pk, model):
         toolbar.append({
             'type': 'link',
             'view': f'{base_name}_list',
-            'label': crud_smart_button('list')})
+            'label': crud_smart_button('list') if label_and_icon else crud_icon('list'),
+            'title': crud_label('list')})
     if request.user.has_perm(
             f"{content_type.app_label}.change_{content_type.model}"):
         toolbar.append({
             'type': 'link_pk',
             'view': f'{base_name}_update',
-            'pk': pk,
-            'label': crud_smart_button('update')})
+            'pk': object.pk,
+            'label': crud_smart_button('update') if label_and_icon else crud_icon('update'),
+            'title': crud_label('update')})
     if request.user.has_perm(
             f"{content_type.app_label}.delete_{content_type.model}"):
         toolbar.append({
             'type': 'link_pk_del',
             'view': f'{base_name}_delete',
-            'pk': pk,
-            'label': crud_smart_button('delete')})
+            'pk': object.pk,
+            'label': crud_smart_button('delete') if label_and_icon else crud_icon('delete'),
+            'title': crud_label('delete')})
+    next = GetNextPrevObject(object)
+    prev = GetNextPrevObject(object, True)
+    if prev:
+        toolbar.append({
+            'type': 'link_pk',
+            'label': '<i class="fas fa-chevron-left"></i>',
+            'title': 'Anterior',
+            'view': f'{base_name}_read',
+            'pk': prev.pk})
+    if next:
+        toolbar.append({
+            'type': 'link_pk',
+            'label': '<i class="fas fa-chevron-right"></i>',
+            'title': 'Anterior',
+            'view': f'{base_name}_read',
+            'pk': next.pk})
     return toolbar
+
+def get_model_attr(instance, attr):
+    """Example usage: get_model_attr(instance, 'category__slug')"""
+    for field in attr.split('__'):
+        if instance is None:
+            break;
+        instance = getattr(instance, field)
+    return instance
+
+def GetNextPrevObject(instance, prev=False, qs=None, loop=False):
+    if not qs:
+        qs = instance.__class__.objects.all()
+    if prev:
+        qs = qs.reverse()
+        lookup = 'lt'
+    else:
+        lookup = 'gt'
+    q_list = []
+    prev_fields = []
+    if qs.query.extra_order_by:
+        ordering = qs.query.extra_order_by
+    elif qs.query.order_by:
+        ordering = qs.query.order_by
+    elif qs.query.get_meta().ordering:
+        ordering = qs.query.get_meta().ordering
+    else:
+        ordering = []
+    ordering = list(ordering)
+    if 'pk' not in ordering and '-pk' not in ordering:
+        ordering.append('pk')
+        qs = qs.order_by(*ordering)
+    for field in ordering:
+        if field[0] == '-':
+            this_lookup = (lookup == 'gt' and 'lt' or 'gt')
+            field = field[1:]
+        else:
+            this_lookup = lookup
+        q_kwargs = dict([(f, get_model_attr(instance, f))
+                         for f in prev_fields if get_model_attr(instance, f) is not None])
+        key = "%s__%s" % (field, this_lookup)
+        q_kwargs[key] = get_model_attr(instance, field)
+        if q_kwargs[key] is None:
+            del(q_kwargs[key])
+        q_list.append(models.Q(**q_kwargs))
+        prev_fields.append(field)
+    try:
+        obj = qs.filter(reduce(models.Q.__or__, q_list))[0]
+        return obj if instance.pk != obj.pk else None
+    except IndexError:
+        length = qs.count()
+        if loop and length > 1:
+            obj = qs[0]
+            return obj if instance.pk != obj.pk else None
+    return None

--- a/zend_django/user_vw.py
+++ b/zend_django/user_vw.py
@@ -36,7 +36,7 @@ from zend_django.templatetags.op_helpers import action_label
 from zend_django.templatetags.op_helpers import crud_icon
 from zend_django.templatetags.op_helpers import crud_label
 from zend_django.templatetags.op_helpers import crud_smart_button
-from zend_django.templatetags.utils import GenerateReadCRUDToolbar
+from zend_django.templatetags.utils import (GenerateReadCRUDToolbar)
 
 
 def template_base_path(file):
@@ -91,7 +91,7 @@ class Read(GenericRead):
             'right': frmUserRight(instance=obj),
         }
         toolbar = GenerateReadCRUDToolbar(
-            request, self.model_name, obj.pk, self.main_data_model)
+            request, self.model_name, obj, self.main_data_model)
         return render(request, self.html_template, {
             'titulo': obj,
             'titulo_descripcion': self.titulo_descripcion,

--- a/zend_django/views.py
+++ b/zend_django/views.py
@@ -128,7 +128,7 @@ class GenericRead(View):
         obj = self.main_data_model.objects.get(pk=pk)
         form = self.base_data_form(instance=obj)
         toolbar = GenerateReadCRUDToolbar(
-            request, self.model_name, pk, self.main_data_model)
+            request, self.model_name, obj, self.main_data_model)
         return render(request, self.html_template, {
             'titulo': obj,
             'titulo_descripcion': self.titulo_descripcion,


### PR DESCRIPTION
Actualizaciones:

- Añadir botones anterior y siguiente en las vistas singulares a partir de la actualización de `zend_django/templatetags/utils.py.GenerateReadCRUDToolbar` y añadiendo sus correspondientes `Action_icons` y `Action_labels`
- Añadir el parámetro title en los botones de la barra de herramientas mostrada en `html_templates/zend_django/html/toolbar.html` y generada por `zend_django/templatetags/utils.py.GenerateReadCRUDToolbar`